### PR TITLE
Adjust exam guidance for programming-focused cohort

### DIFF
--- a/questions/examen_terminal.md
+++ b/questions/examen_terminal.md
@@ -1,0 +1,33 @@
+# Propositions de questions et parties pratiques pour l'examen terminal
+
+Ces suggestions prennent en compte un contexte d'examen avec accès aux notes et aux projets personnels, sans Internet, et un temps limité. Les étudiants disposent d'un robot Makeblock Ranger déjà monté : l'accent est mis sur la programmation et l'utilisation des librairies fournies plutôt que sur l'électronique. Les parties pratiques sont prévues pour être réalisables en moins d'une heure.
+
+## Questions théoriques possibles
+- Différence entre Arduino IDE et VS Code pour programmer le robot : avantages/inconvénients, éléments à configurer pour chaque environnement.
+- Rôle de la fonction `millis()` dans la gestion du temps sans bloquer l'exécution (comparaison implicite avec `delay()`).
+- Étapes pour lire un bouton avec `digitalRead()` et expliquer pourquoi utiliser `INPUT_PULLUP` dans certains montages.
+- Comment générer un signal PWM avec `analogWrite()` et dans quels cas l'utiliser (LED, vitesse moteur, servo).
+- Comment lire un capteur analogique avec `analogRead()` et interpréter sa valeur (ex. humidité ou luminosité).
+- Pourquoi préférer un filtrage logiciel ou une moyenne glissante lors de la lecture d'un capteur ultrasonique.
+- Principe de base d'un capteur ultrasonique (émission/réflexion) et rôle de la constante de vitesse du son.
+- Différence entre interruption matérielle et boucle principale : cas d'usage et précautions (délais courts, variables volatiles).
+- Fonctionnement d'un bus I2C sur le robot : rôle des broches SDA/SCL, adresses d'esclaves et usage de la librairie fournie sans entrer dans les détails électroniques.
+- Usage de la librairie du robot (ex. `MeAuriga.h`) : ce qu'elle apporte par rapport aux appels Arduino standards.
+- Principes d'un PID vu en classe : rôle de chaque terme et effets attendus (réduction d'oscillation, stabilité, vitesse de réponse).
+- Pourquoi calibrer un suiveur de ligne avant une course et comment interpréter les valeurs lues par le capteur.
+- Décrire l'organisation d'une machine à états finis pour le robot : états, événements, transitions et actions associées.
+- Comment synchroniser deux moteurs pour aller droit (ex. lecture encodeurs + correction proportionnelle ou PID simple).
+- Stratégies pour diagnostiquer des caractères illisibles dans le moniteur série (vitesse baud, câblage, alimentation du port USB).
+
+## Parties pratiques (<= 1h chacune)
+- **Lecture de bouton et rétroaction lumineuse** : coder la détection d'un bouton avec antirebond (logiciel simple) et faire clignoter une DEL ou l'anneau de DELS en conséquence. Évaluer la stabilité et la réactivité sans modifier le câblage.
+- **Affichage périodique de mesures** : lire le capteur ultrasonique (ou un autre capteur analogique disponible) toutes les 500 ms sans `delay()`, afficher la distance sur le port série et allumer une DEL si un seuil est franchi. Vérifier le respect du timing avec `millis()`.
+- **Pilotage basique des moteurs** : faire avancer le robot en ligne droite sur 1 mètre en utilisant `analogWrite()` ou l'API moteur du robot, puis revenir au point de départ en inversant le sens. Prévoir un arrêt d'urgence via un bouton.
+- **Test rapide du suiveur de ligne** : écrire un programme minimal qui lit les valeurs du capteur de ligne, les affiche dans le moniteur série et ajuste la puissance des moteurs pour rester centré sur une piste en « S » courte. Objectif : obtenir un comportement stable en moins d'une heure.
+- **Rotation contrôlée** : utiliser les encodeurs pour faire pivoter le robot d'un angle donné (ex. 90°) avec une boucle de correction proportionnelle. La validation se fait en mesurant l'écart angulaire après 3 essais.
+
+## Conseils pour limiter le stress en examen
+- Commencer par relire les exemples de code fournis en cours ou dans vos projets avant d'écrire du nouveau code.
+- Garder un modèle de boucle principale non bloquante sous la main et le réutiliser pour tous les exercices.
+- Tester chaque fonctionnalité de façon incrémentale (lecture du capteur, puis affichage, puis action sur le moteur) pour éviter les régressions.
+- Documenter rapidement dans le code (commentaires courts) chaque hypothèse ou valeur de calibration afin de gagner du temps lors du débogage.

--- a/questions/readme.md
+++ b/questions/readme.md
@@ -1,18 +1,18 @@
 # Questions types pour l'évaluation terminale
 
-Voici une liste de questions typiques qui pourraient être posées lors de l'évaluation terminale. 
+Voici une liste de questions typiques qui pourraient être posées lors de l'évaluation terminale.
 
 - Il est possible d'utiliser Visual Studio Code pour programmer sur le robot?
 - Arduino IDE est le seul environnement de développement adapté pour programmer sur le robot?
-- Sur le robot, on retrouve un lecteur d'humidité et de température? 
+- Sur le robot, on retrouve un lecteur d'humidité et de température?
 - Sur le robot, il y a des encodeurs et des capteurs de luminosité?
-- Pourquoi il est proscrit d'utiliser l'instruction `delay()` dans le code? 
-- Sur un Arduino Mega ou le robot, que permet de faire l'instruction `digitalWrite(13, HIGH)` (Écris la meilleure réponse)? 
-- Considère la variable `int btn_pin = 5;`, quelle instruction permet de configurer la broche du bouton en entrée? 
-- Quelle fonction permet de retouner le temps écoulé en milliseconde depuis le démarrage du programme? 
-- Pourquoi est-il préférable d'utiliser le type `unsigned long` pour stocker le temps écoulé depuis le démarrage du programme? 
-- À quoi sert l'instruction `Serial.begin(9600);`? 
-- Quelle librairie doit-on importer pour utiliser les fonctions du robot? 
+- Pourquoi il est proscrit d'utiliser l'instruction `delay()` dans le code?
+- Sur un Arduino Mega ou le robot, que permet de faire l'instruction `digitalWrite(13, HIGH)` (Écris la meilleure réponse)?
+- Considère la variable `int btn_pin = 5;`, quelle instruction permet de configurer la broche du bouton en entrée?
+- Quelle fonction permet de retouner le temps écoulé en milliseconde depuis le démarrage du programme?
+- Pourquoi est-il préférable d'utiliser le type `unsigned long` pour stocker le temps écoulé depuis le démarrage du programme?
+- À quoi sert l'instruction `Serial.begin(9600);`?
+- Quelle librairie doit-on importer pour utiliser les fonctions du robot?
 - Selon ce que l'on a vu en classe, quels sont les deux principes de programmation nécessaire pour implémenter une machine à état fini dans un robot? Et à quoi servent-il?
 - Quelle est l'utilité du MPU-6050 dans le robot?
 - Sur l'ensemble des capteurs présents sur le robot, nommes-en trois?
@@ -21,7 +21,9 @@ Voici une liste de questions typiques qui pourraient être posées lors de l'év
 - Décris ce qu'est une fonction d'interruption et à quoi elle peut servir.
 - Quelle est la différence entre une fonction d'interruption et une fonction normale?
 - Pourquoi est-il mieux d'utiliser une machine à état fini au lieu d'un programme séquentiel pour contrôler le robot?
-- J'ai plusieurs appareils fonctionnant avec le protocole I2C. Je voudrais les connecter sur le port I2C du robot. Conceptuellement, comment puis-je faire cela? Qu'est-ce qui permet de différencier à quel appareil le code communique?
+- J'ai plusieurs appareils fonctionnant avec le protocole I2C. Je voudrais les connecter sur le port I2C du robot déjà monté. Conceptuellement, comment le code choisit-il l'appareil ciblé (ex. adresse I2C) sans qu'on ait besoin de modifier le câblage existant?
 - Lorsque j'active le moniteur série, je reçois des caractères bizarres comme-ci "`3??à.□□□□" Pourquoi?
+
+Pour des propositions additionnelles incluant des parties pratiques d'une durée maximale d'une heure, consultez [Propositions de questions et parties pratiques pour l'examen terminal](examen_terminal.md).
 
 Si vous avez des questions ou commentaires, posez-les en utilisant l'onglet `Issues` en haut de la page.


### PR DESCRIPTION
## Summary
- clarify that the exam context uses a preassembled Makeblock Ranger and emphasises programming and provided libraries
- reword I2C-related questions to focus on addressing and library use without electronics details

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69270ec560c88331a143d8021e7c9223)